### PR TITLE
Added Pluralsight to learning resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,6 +264,7 @@ Create mobile apps with device feature-driven workflow using your standard or cu
  * [Salesforce PartnerForce](https://twitter.com/partnerforce)
 
 ### Learning Salesforce Platform
+* [Pluralsight Courses](https://www.pluralsight.com/search?q=salesforce&categories=course) - A rapidly growing collection of courses covering Apex, Lightning, Integration and more. Authored by Salesforce MVPs and Certified Advanced Developers like Dan Appleman, David Liu, Don Robins, Sara Morgan and others.
 * [Trailhead](https://developer.salesforce.com/trailhead) - Trailhead teaches you how to build cloud apps for free with fun, interactive tutorials. Stand out by learning in-demand Salesforce development skills.
 * [Udemy Course](https://www.udemy.com/salesforce-training/) - Hands on detailed and complete Instruction for both Admin and Developer part of Salesforce CRM.
 * [Udacity Course](https://www.udacity.com/course/intro-to-point-click-app-development--ud162) - This class teaches you how to build powerful web and mobile apps and host them in the cloud, without writing a line of code.


### PR DESCRIPTION
In README.md in the section on _Learning Salesforce Platform_ I added an entry for Pluralsight courses with a link to the various courses that pertain to Salesforce.