### PR TITLE
Removed unavailable Udemy course

### DIFF
--- a/README.md
+++ b/README.md
@@ -299,7 +299,6 @@ Create mobile apps with device feature-driven workflow using your standard or cu
 
 ### Learning Salesforce Platform
 * [Trailhead](https://developer.salesforce.com/trailhead) - Trailhead teaches you how to build cloud apps for free with fun, interactive tutorials. Stand out by learning in-demand Salesforce development skills.
-* [Udemy Course](https://www.udemy.com/salesforce-training/) - Hands on detailed and complete Instruction for both Admin and Developer part of Salesforce CRM.
 * [Udacity Course](https://www.udacity.com/course/intro-to-point-click-app-development--ud162) - This class teaches you how to build powerful web and mobile apps and host them in the cloud, without writing a line of code.
 * [Pluralsight Course](https://www.pluralsight.com/courses/apex-absolute-beginner-guide-coding-salesforce) - A crash course on how to code Apex taught by four time Salesforce MVP David Liu.
 


### PR DESCRIPTION
The Udemy course at [https://www.udemy.com/salesforce-training/](https://www.udemy.com/salesforce-training/) is no longer available for purchase, so I removed it.