### PR TITLE
Remove Mavansmate, BrainEngine

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,9 +51,9 @@ Read [the awesome manifesto](https://github.com/mailtoharshit/awesome-salesforce
 ### IDE
 <img src="https://raw.githubusercontent.com/mailtoharshit/awesome-salesforce/master/src/ideicon.png" align="right" width="120">
 
+The previously popular Mavansmate editor(http://mavensmate.com/) has now ceased developement.
+
 * [Force.com IDE](https://developer.salesforce.com/page/Force.com_IDE) - Based on Eclipse Platform, supported and packaged by Salesforce.com
-* [Mavensmate for Sublime, Atom & VSCode](http://mavensmate.com/) - Widely popular, 3rd party plugin package for Sublime Text, Atom & Visual Studio Code editors
-* [BrainEngine](http://www.brainengine.net/) - Premier IDE for Force.com Development, based on Visual Studio.
 * [ASIDE.IO](https://www.aside.io) - Online Editor, fast and connects to any Salesforce org quickly.
 * [WelkinSuite for Windows](https://welkinsuite.com/) - Desktop Editor for force.com application, free for use, pay for support.
 * [C9.IO](https://get.c9.io/salesforce/) - Online Editor, connects to any Salesforce org quickly.
@@ -63,18 +63,16 @@ Read [the awesome manifesto](https://github.com/mailtoharshit/awesome-salesforce
 <img src="https://raw.githubusercontent.com/mailtoharshit/awesome-salesforce/master/src/forceplug.png" align="right" width="220">
 
 * [Eclipse Plugin](http://media.developerforce.com/force-ide/eclipse42) - Based on Eclipse Platform, supported and packaged by Salesforce.com
-* [Mavensmate Plugin for Sublime](https://mavensmate.com/Plugins/Sublime_Text/Installation) - Widely popular, 3rd party plugin package for Sublime Text Editor
 * [Atom Plugin](https://github.com/joeferraro/MavensMate-Atom)- MavensMate plugin for building Salesforce.com/Force.com/Salesforce1 applications inside GitHub's Atom text editor
 * Visual Studio Code
   * [ForceCode](https://github.com/celador/ForceCode) is a Visual Studio Code extension for Salesforce development
-  * [Mavensmate](https://marketplace.visualstudio.com/items?itemName=DavidHelmer.mavensmate) Mavensmate extension for VS code.  Very close in feature parity to Sublime version.
   * [Auto-complete +](https://marketplace.visualstudio.com/items?itemName=chuckjonas.apex-autocomplete) Provides auto-completions for Apex & Visualforce, Go-To & Peek Definition and Realtime Syntax Checking
 * [ApexMate](https://github.com/superfell/ApexMate)- Apex Plugin for TextMate.
 * [VimAwesome](http://vimawesome.com/plugin/vim-force-com)- VIM Plugin for Force.com.
 * [Force.com CLI](https://force-cli.heroku.com/)- Command-line interface to Force.com.
 * [HaoIDE](https://github.com/xjsender/haoide) - Sublime Plugin for Force.com
 * [JedIDE](https://plugins.jetbrains.com/plugin/9238) - Force.com integration for IntelliJ IDEA
-
+* [Mavensmate](https://marketplace.visualstudio.com/items?itemName=DavidHelmer.mavensmate) Mavensmate extension for VS code.  The main Mavansmate project is now no longer active, so this plugin may be of limited use.
 
 ### Salesforce Custom Search Engines
 


### PR DESCRIPTION
According to the website, the author of Mavansmate has given up on this project. This list would be cleaner without those links. There is no longer any downloadable content on mavensmate.com. Brainengine website now owned by a different domain and can't find any current version with Google search.