### PR TITLE
Add official Salesforce VS Code extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ The previously popular Mavansmate editor(http://mavensmate.com/) has now ceased 
 * [Eclipse Plugin](http://media.developerforce.com/force-ide/eclipse42) - Based on Eclipse Platform, supported and packaged by Salesforce.com
 * [Atom Plugin](https://github.com/joeferraro/MavensMate-Atom)- MavensMate plugin for building Salesforce.com/Force.com/Salesforce1 applications inside GitHub's Atom text editor
 * Visual Studio Code
+  * [Salesforce Extensions for VS Code](https://github.com/forcedotcom/salesforcedx-vscode) are the official Salesforce VS Code extensions.
   * [ForceCode](https://github.com/celador/ForceCode) is a Visual Studio Code extension for Salesforce development
   * [Auto-complete +](https://marketplace.visualstudio.com/items?itemName=chuckjonas.apex-autocomplete) Provides auto-completions for Apex & Visualforce, Go-To & Peek Definition and Realtime Syntax Checking
 * [ApexMate](https://github.com/superfell/ApexMate)- Apex Plugin for TextMate.


### PR DESCRIPTION
> "the Salesforce Extensions for VS Code are the future of Salesforce development. We are dedicating our resources to make this the best and most enjoyable desktop editor for Salesforce developers. " [Salesforce Blog](https://developer.salesforce.com/blogs/2018/02/salesforce-extensions-vs-code.html)

For additional info, see:
* https://forcedotcom.github.io/salesforcedx-vscode/ (github pages docs site for that repo)
* Direct link to VS Code extension page: https://marketplace.visualstudio.com/items?itemName=salesforce.salesforcedx-vscode
* Apex replay debugger https://developer.salesforce.com/blogs/2018/06/salesforce-for-vs-code-apex-replay-debugger-and-more.html
* Salesforce VS Questions, Answered: https://developer.salesforce.com/blogs/2018/10/vs-code-for-salesforce-developers-your-questions-answered.html
* Webinar: [VS Code for Salesforce Developers](https://developer.salesforce.com/events/webinars/vs-code)
