### PR TITLE
Updates README link

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,7 +210,7 @@ The previously popular Mavansmate editor(http://mavensmate.com/) has now ceased 
 ### Open Source Projects Repositories from Salesforce
 
 * [Salesforce Git Repo](https://github.com/forcedotcom) - Grab all latest salesforce open source projects here, you will find awesome projects, framework, libraries that salesforce and opened for the world
-* [ForcedotCom Labs](https://github.com/ForceDotComLabs) - Checkout open source and experimental projects from Salesforce Team. Get an early access to features that can qualify in feature and contribute your ideas 
+* [Salesforce Labs](https://github.com/salesforcelabs) - Checkout open source and experimental projects from Salesforce Team. Get an early access to features that can qualify in feature and contribute your ideas 
 
 <img src="https://raw.githubusercontent.com/mailtoharshit/awesome-salesforce/master/src/open%20source.png" align="right" width="90">
 


### PR DESCRIPTION
Updates README's link to rebranded Salesforce Labs repo.  The currently listed one (ForceDotComLabs: [https://github.com/ForceDotComLabs](https://github.com/ForceDotComLabs)) is deprecated and has moved to @SalesforceLabs ([https://github.com/salesforcelabs](https://github.com/salesforcelabs))