### PR TITLE
Force.com IDE retired

### DIFF
--- a/README.md
+++ b/README.md
@@ -339,6 +339,7 @@ Design and build apps that separate UI, logic, and data using Mobile Pack for An
 
 ### Podcasts
 * [Good day, Sir! Podcast](https://www.gooddaysirpodcast.com/) - A WEEKLY TECHNOLOGY AND SOFTWARE DEVELOPMENT PODCAST, WITH A STRONG FOCUS ON THE SALESFORCE PLATFORM.
+* [Salesforce Posse](https://salesforceposse.com) - The Salesforce Posse podcast was created to tell the world about Salesforce development and architecture best practice and news from the Salesforce eco-system.
 * [SalesforceWay Podcast](https://salesforceway.com/podcast) - A WEEKLY SALESFORCE DEVELOPER TARGETED PODCAST.
 
 ## Contribute

--- a/README.md
+++ b/README.md
@@ -339,8 +339,8 @@ Design and build apps that separate UI, logic, and data using Mobile Pack for An
 
 ### Podcasts
 * [Good day, Sir! Podcast](https://www.gooddaysirpodcast.com/) - A WEEKLY TECHNOLOGY AND SOFTWARE DEVELOPMENT PODCAST, WITH A STRONG FOCUS ON THE SALESFORCE PLATFORM.
-* [Salesforce Posse](https://salesforceposse.com) - The Salesforce Posse podcast was created to tell the world about Salesforce development and architecture best practice and news from the Salesforce eco-system.
 * [SalesforceWay Podcast](https://salesforceway.com/podcast) - A WEEKLY SALESFORCE DEVELOPER TARGETED PODCAST.
+* [Salesforce Posse](https://salesforceposse.com) - The Salesforce Posse podcast was created to tell the world about Salesforce development and architecture best practice and news from the Salesforce eco-system.
 
 ## Contribute
 

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Pull requests might be left open for a period of time to let the community chime
 
 The previously popular Mavansmate editor(http://mavensmate.com/) has now ceased developement.
 
-* [Force.com IDE](https://developer.salesforce.com/page/Force.com_IDE) - Based on Eclipse Platform, supported and packaged by Salesforce.com
+* [Force.com IDE](https://developer.salesforce.com/page/Force.com_IDE) - Based on Eclipse Platform, supported and packaged by Salesforce.com(NOW RETIRED)
 * [ASIDE.IO](https://www.aside.io) - Online Editor, fast and connects to any Salesforce org quickly.
 * [WelkinSuite for Windows](https://welkinsuite.com/) - Desktop Editor for force.com application, free for use, pay for support.
 * [C9.IO](https://get.c9.io/salesforce/) - Online Editor, connects to any Salesforce org quickly.


### PR DESCRIPTION
The force.com IDE is now retired . Please read the following [documentation](https://releasenotes.docs.salesforce.com/en-us/spring19/release-notes/rn_vscode_forcecom_ide_retirement.htm) for more details.